### PR TITLE
Make it not crash when the stack frame contains something other than Python code

### DIFF
--- a/markii/markii.py
+++ b/markii/markii.py
@@ -87,6 +87,19 @@ def getframes(app_root=""):
         for item in items:
             frame, filename, line, func, lines, _ = item
             app_local = filename.startswith(app_root)
+
+            # Check for non-Python code BEFORE trying/failing to parse it!
+            if not filename.lower().endswith(".py"):
+                # This isn't Python code (possibly a Jinja2 renderer exception),
+                # so just cobble-up a bare-bones Frame for it, since the
+                # tokenizer would CRASH trying to parse it as Python code.
+                frames.append(Frame(
+                    func, {}, None, {},
+                    filename, (), line, lines, app_local
+                ))
+                continue
+
+            # It's Python code, so parse out lots of cool extra goodies.
             f_locals = frame.f_locals
             try:
                 lines = [l.strip() for l in lines]


### PR DESCRIPTION
This was blowing up when the stack trace originated from the Jinja2 template renderer, because the frame was this:

`FRAME=Frame_Info: <frame object at 0xfadd2800> code=<code object block "tab" at 0xfaf55de8, file "templates/account/billing/base.html", line 13> lineno=13 `

and inspect.getblock() choked on this tokenizer error:

`INSPECT_GETBLOCK_UNEXPECTED_EXCEPTION: ('EOF in multi-line statement', (17, 0))`

when it was fed these lines:

`LINES=["{% extends 'account/base.html' %}\n", '\n', '{% block tab %}\n', '<div>\n', ' <ul class="nav nav-tabs">\n', ' <li{% if request.path == url(\'subscription\') %} class="active"{% endif %}><a href="{{url(\'subscription\')}}">Subscription</a></li>\n', " {% if account.status not in ('past_due', 'pending') %}\n", ' <li{% if request.path == url(\'upgrade_subscription\') %} class="active"{% endif %}><a href="{{url(\'upgrade_subscription\')}}">Upgrade My Account</a></li>\n', ' {% endif %}\n', ' {#<li{% if request.path == url(\'payment_method\') %} class="active"{% endif %}><a href="{{url(\'payment_method\')}}">Payment Method</a></li>#}\n', ' <li{% if request.path == url(\'billing_history\') %} class="active"{% endif %}><a href="{{url(\'billing_history\')}}">Billing History</a></li>\n', ' </ul>\n', ' {% block billing_tab %}\n', ' {% endblock %}\n', '</div>\n', '{% endblock %}\n']`